### PR TITLE
added support for [startanode] mod

### DIFF
--- a/give_initial_stuff/depends.txt
+++ b/give_initial_stuff/depends.txt
@@ -1,2 +1,3 @@
 default
 water?
+startanode?

--- a/give_initial_stuff/init.lua
+++ b/give_initial_stuff/init.lua
@@ -10,6 +10,36 @@ local chest_formspec =
 	"listring[current_player;main]" ..
 	default.get_hotbar_bg(0,4.85)
 
+local function fill_chest(blockpos)
+	local meta = minetest.get_meta(blockpos)
+	meta:set_string("formspec", chest_formspec)
+	local inv = meta:get_inventory()
+	inv:set_size("main", 8*4)
+	-- Fill with stuff
+	inv:set_stack("main", 1, 'default:cobble 12')
+	inv:set_stack("main", 2, 'nodetest:papyrus_roots 6')
+	inv:set_stack("main", 3, 'default:dirt 2')
+	inv:set_stack("main", 4, 'default:sapling')
+	inv:set_stack("main", 5, 'default:junglesapling')
+	if minetest.get_modpath("conifer") then
+		inv:set_stack("main", 6, 'conifer:sapling')
+	end
+end
+
+if minetest.global_exists("startanode") then
+	minetest.log("Undernull startup player chests handeled by startanode mod")
+	if minetest.get_modpath("water") then
+		local water_level = minetest.setting_get("water_level") or 0
+		startanode.min_pos.y = water_level -1
+		startanode.max_pos.y = water_level -1
+	end
+	startanode.node_name = "default:chest"
+	startanode.after_place_func = function(player, pos)
+		fill_chest(pos)
+	end
+	return
+end
+
 minetest.register_on_generated(function(minp, maxp, seed)
 	local spawn = minetest.setting_get_pos("static_spawnpoint")
 	if minetest.get_gametime() < 5 then
@@ -20,21 +50,7 @@ minetest.register_on_generated(function(minp, maxp, seed)
 		end
 		-- Create chest
 		minetest.set_node(blockpos, {name="default:chest"})
-		local meta = minetest.get_meta(blockpos)
-		meta:set_string("formspec", chest_formspec)
-		local inv = meta:get_inventory()
-		inv:set_size("main", 8*4)
-
-		-- Fill with stuff
-		inv:set_stack("main", 1, 'default:cobble 12')
-		inv:set_stack("main", 2, 'nodetest:papyrus_roots 6')
-		inv:set_stack("main", 3, 'default:dirt 2')
-		inv:set_stack("main", 4, 'default:sapling')
-		inv:set_stack("main", 5, 'default:junglesapling')
-		if minetest.get_modpath("conifer") then
-			inv:set_stack("main", 6, 'conifer:sapling')
-		end
-
+		fill_chest(blockpos)
 		local filepath = minetest.get_worldpath().."/origin.mt"
 		local file = io.open(filepath, "w")
 		file:write(minetest.pos_to_string(blockpos))


### PR DESCRIPTION
Optional support for my new startanode mod. See https://forum.minetest.net/viewtopic.php?f=9&t=17493

If the startanode is found the startanode is responsible for the placing the chest with inital stuff. That means the chest will not be placed at the point zero anymore (like origin), instead each new player get an own chest.
By the way, maybe the mod "give_initial_stuff" needs to be renamed since it is 90% "origin" mod?