### PR TITLE
added optional support for smart_inventory recipes database

### DIFF
--- a/crushingfurnace/depends.txt
+++ b/crushingfurnace/depends.txt
@@ -1,1 +1,2 @@
 default
+smart_inventory?

--- a/crushingfurnace/init.lua
+++ b/crushingfurnace/init.lua
@@ -304,3 +304,21 @@ minetest.register_craft({
 		{'group:stone', 'group:stone', 'group:stone'},
 	}
 })
+
+if minetest.global_exists("smart_inventory") and smart_inventory.crecipes.add_recipes_from_list then
+	-- add grinder recipes to smart inventory database
+	local crecipes = smart_inventory.crecipes
+	local cache = smart_inventory.cache
+	local function fill_citem_recipes()
+		local recipelist = {}
+		for _, e in ipairs(crushingfurnace_receipes) do
+			table.insert(recipelist, {
+					output = e[2],
+					items = {e[1]},
+					type = "grinding"
+				})
+		end
+		crecipes.add_recipes_from_list(recipelist)
+	end
+	 cache.register_on_cache_filled(fill_citem_recipes)
+end


### PR DESCRIPTION
This PR adds (optional) the crushingfurnace recipes to the smart_inventory cache. So you can get the information about possible grindings in inventory in the smart way.
smart_inventory as of today required