### PR TITLE
remove initial default:junglesapling and conifer:sapling.

### DIFF
--- a/give_initial_stuff/init.lua
+++ b/give_initial_stuff/init.lua
@@ -19,11 +19,7 @@ local function fill_chest(blockpos)
 	inv:set_stack("main", 1, 'default:cobble 12')
 	inv:set_stack("main", 2, 'nodetest:papyrus_roots 6')
 	inv:set_stack("main", 3, 'default:dirt 2')
-	inv:set_stack("main", 4, 'default:sapling')
-	inv:set_stack("main", 5, 'default:junglesapling')
-	if minetest.get_modpath("conifer") then
-		inv:set_stack("main", 6, 'conifer:sapling')
-	end
+	inv:set_stack("main", 4, 'default:sapling 2')
 end
 
 if minetest.global_exists("startanode") then


### PR DESCRIPTION
I removed them because it should be obtained ingame. Currently usefull with my fork (https://github.com/bell07/minetest-compost) of compost that can provide the saplings as rare gift
